### PR TITLE
Workflow de release añadido

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Tag and release
+on:
+  workflow_dispatch:
+env:
+  repo_git_user: 'github-actions'
+  repo_git_mail: 'github-actions@github.com'
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.1.6
+      
+      - name: Get poetry version
+        id: poetry_ver
+        run: |
+                VERSION=$( poetry version | cut -d ' ' -f 2 )
+                echo "::set-output name=VERSION::$VERSION"
+                echo $VERSION
+                
+      - name: Create Git Tag
+        run: |
+          VERSION=${{ steps.poetry_ver.outputs.VERSION }}
+          git config user.name  ${{ env.repo_git_user }}
+          git config user.email ${{ env.repo_git_mail }}
+          git tag ${VERSION}
+          git push origin ${VERSION}
+          
+      - name: Create Github Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ steps.poetry_ver.outputs.VERSION }}
+          tag: ${{ steps.poetry_ver.outputs.VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## WORKFLOW RELEASE
Now that the project is shared as a python package thanks to poetry, it is important to set releases with a correct version (the version indicated in pyproject.toml). 
This way every other python script that uses this project as a dependency should can this repo with a tag in its .toml:
https://python-poetry.org/docs/dependency-specification/#git-dependencies

With the new workflow, in order to make a release you have to manually run the "Tag and release" workflow and a new release will be published using the same version as indicated in the `pyproject.toml`

I think that issue #1 can be resolved as there is also a .github/workflows/pr-verify.yaml.